### PR TITLE
Configurable Mojang Session Server

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
@@ -75,7 +75,8 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
 
   private static final Logger logger = LogManager.getLogger(LoginSessionHandler.class);
   private static final String MOJANG_HASJOINED_URL =
-      "https://sessionserver.mojang.com/session/minecraft/hasJoined?username=%s&serverId=%s";
+    System.getProperty("mojang.sessionserver", "https://sessionserver.mojang.com/session/minecraft/hasJoined")
+      .concat("?username=%s&serverId=%s");
 
   private final VelocityServer server;
   private final MinecraftConnection mcConnection;


### PR DESCRIPTION
Lets the mojang session server URL to be handled via a customized auth service.

This is something which minecraft itself implements for change in their stock jars, would be nice to have something similar here.